### PR TITLE
Switch from println to debug logging.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 ﻿[package]
 name = "smallpt"
-version = "0.1.6"
+version = "0.1.7"
 license = "MIT"
 description = "A small ray/pathtracer in Rust, inspired by Kevin Beason's educational 99-lines ray/pathtracer (http://www.kevinbeason.com/smallpt/)"
 keywords = ["raytracer", "raytracing", "ray-tracing", "path-tracer"]
@@ -18,3 +18,4 @@ structopt = "0.2"
 cgmath = "0.16.1"
 rand = "0.5.0"
 num_cpus = "1.8.0"
+log = "0.4.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,7 @@
 #![allow(unused_imports)]
 
+#[macro_use]
+extern crate log;
 extern crate cgmath;
 extern crate num_cpus;
 extern crate rand;
@@ -105,7 +107,7 @@ pub fn trace(
                 }
             });
 
-        println!("Rendering ({} spp) {}%\r", num_samples, outer_chunk_index);
+        debug!("Rendering ({} spp) {}%\r", num_samples, outer_chunk_index);
     }
 }
 


### PR DESCRIPTION
Instead of printing out the "Rendering xx" line for progress using println! it now uses the debug! macro from the log crate which works better for libraries as it allows the user of the library to control which log output to get and where to put it (log file, stdout, stderr) and filter it and such.